### PR TITLE
Fix build permission errors during 'gem install bundler'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: ruby
-rvm: system
 
 branches:
   only:


### PR DESCRIPTION
Guessing this is related to the Bundler 2.0 release. TravisCI now has a default
step that does a 'gem install bundler', which fails because we're using the
system ruby that would require sudo to install under.